### PR TITLE
feat: initial docker setup

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,40 @@
+# Use an official PHP-FPM base image
+FROM php:8.4-fpm
+
+# Install required packages and PHP extensions
+RUN apt-get update && apt-get install -y \
+    nginx \
+    curl \
+    zip \
+    unzip \
+    git \
+    libpng-dev \
+    libonig-dev \
+    libxml2-dev \
+    libzip-dev \
+    supervisor \
+    && docker-php-ext-install \
+        mbstring \
+        exif \
+        pcntl \
+        bcmath \
+        gd \
+        zip \
+        opcache \
+    && apt-get clean && rm -rf /var/lib/apt/lists/*
+
+# Set working directory
+WORKDIR /var/www/html
+
+# Copy Nginx configuration
+COPY ./nginx.conf /etc/nginx/sites-available/default
+
+# Copy Supervisor configuration
+COPY ./supervisord.conf /etc/supervisor/conf.d/supervisord.conf
+
+# Expose ports for Nginx
+# TODO: work out how to open a port
+# EXPOSE 4001
+
+# Start PHP-FPM and Nginx together
+CMD ["supervisord", "-c", "/etc/supervisor/conf.d/supervisord.conf"]

--- a/README.md
+++ b/README.md
@@ -27,6 +27,15 @@ If you decided that you want to reset your project and start with a fresh WordPr
 
 check the code to know what the command do.
 
+### Docker
+
+Replace YOUR_PORT with the port you choose to run on.
+
+```bash
+docker build -t litepress-test .
+docker run -it -p YOUR_PORT:80 -v $(pwd):/var/www litepress-test
+```
+
 ### Notes:
 
 Please note that not all WordPress plugins support sqlite, some uses specific syntax that is supported by mysql only, when creating extra tables.

--- a/nginx.conf
+++ b/nginx.conf
@@ -1,0 +1,22 @@
+server {
+    listen 80;
+    server_name localhost;
+
+    root /var/www/public;
+    index index.php index.html;
+
+    location / {
+        try_files $uri $uri/ /index.php?$query_string;
+    }
+
+    location ~ \.php$ {
+        include snippets/fastcgi-php.conf;
+        fastcgi_pass 127.0.0.1:9000;
+        fastcgi_param SCRIPT_FILENAME $document_root$fastcgi_script_name;
+        fastcgi_param PATH_INFO $fastcgi_path_info;
+    }
+
+    location ~ /\.ht {
+        deny all;
+    }
+}

--- a/supervisord.conf
+++ b/supervisord.conf
@@ -1,0 +1,12 @@
+[supervisord]
+nodaemon=true
+
+[program:php-fpm]
+command=/usr/local/sbin/php-fpm --nodaemonize
+autostart=true
+autorestart=true
+
+[program:nginx]
+command=/usr/sbin/nginx -g "daemon off;"
+autostart=true
+autorestart=true


### PR DESCRIPTION
This sets up nginx with php-fpm using php 8.4, so that you can run this repo via Docker

It now has no moving parts apart from the port, which I'd say I like leaving open (within the docker container it's 80)

Should significantly contribute to, if not Fix #3 