### PR TITLE
[feat] Adding docker build for easy use

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,5 +1,29 @@
-# Use an official PHP-FPM base image
-FROM php:8.4-fpm
+# Build confd stage
+FROM golang:1.22.11-alpine AS confd-builder
+
+ARG CONFD_VERSION=0.18.2
+
+ADD https://github.com/abtreece/confd/archive/v${CONFD_VERSION}.tar.gz /tmp/
+
+RUN apk add --no-cache \
+    bzip2 \
+    make && \
+  mkdir -p /go/src/github.com/abtreece/confd && \
+  cd /go/src/github.com/abtreece/confd && \
+  tar --strip-components=1 -zxf /tmp/v${CONFD_VERSION}.tar.gz && \
+  go install github.com/abtreece/confd && \
+  rm -rf /tmp/v${CONFD_VERSION}.tar.gz
+
+# Main application stage
+FROM php:8.3-fpm
+
+# Set default port
+ARG NGINX_PORT=80
+ENV NGINX_PORT=${NGINX_PORT}
+
+# Copy confd binary from builder stage
+COPY --from=confd-builder /go/bin/confd /usr/local/bin/confd
+RUN chmod u+x /usr/local/bin/confd
 
 # Install required packages and PHP extensions
 RUN apt-get update && apt-get install -y \
@@ -24,16 +48,8 @@ RUN apt-get update && apt-get install -y \
         opcache \
     && apt-get clean && rm -rf /var/lib/apt/lists/*
 
-# Install confd
-RUN wget https://github.com/kelseyhightower/confd/releases/download/v0.16.0/confd-0.16.0-linux-amd64 \
-    && mv confd-0.16.0-linux-amd64 /usr/local/bin/confd \
-    && chmod +x /usr/local/bin/confd
-
 # Set working directory
-WORKDIR /var/www/html
-
-# Create confd structure
-RUN mkdir -p /etc/confd/{conf.d,templates}
+WORKDIR /var/www
 
 # Copy confd configuration
 COPY ./docker/confd/conf.d /etc/confd/conf.d/
@@ -42,12 +58,12 @@ COPY ./docker/confd/templates /etc/confd/templates/
 # Copy Supervisor configuration
 COPY ./docker/supervisord.conf /etc/supervisor/conf.d/supervisord.conf
 
+# Copy custom php settings
+COPY ./docker/php/custom.ini /usr/local/etc/php/conf.d/custom.ini
+
 # Copy entrypoint script
 COPY ./docker/docker-entrypoint.sh /usr/local/bin/
 RUN chmod +x /usr/local/bin/docker-entrypoint.sh
-
-# Set default port
-ENV NGINX_PORT=80
 
 # Expose the port dynamically
 EXPOSE ${NGINX_PORT}

--- a/README.md
+++ b/README.md
@@ -37,6 +37,30 @@ After installation is complete, you can login to your WordPress dashboard using 
 - The default credentials if you used the simple setup
 - The username and password you specified in `ADMIN_USER` and `ADMIN_PASSWORD` if you used the automated setup
 
+## Running with Docker
+
+The project includes Docker support for easy development. To run the project using Docker:
+
+1. Make sure you have Docker and Docker Compose installed on your system.
+
+2. (Optional) Configure the environment variables in `.env`:
+   ```env
+   NGINX_PORT=80       # Change if port 80 is already in use
+   REDIS_PORT=6379     # Change if port 6379 is already in use
+   ```
+
+4. Start the Docker containers:
+   ```bash
+   docker-compose up -d
+   ```
+
+5. Your application will be available at `http://127.0.0.1` (or the port you specified in NGINX_PORT).
+
+The Docker setup includes:
+- PHP-FPM with Nginx
+- Redis for caching
+- Automatic environment configuration
+
 ## Reinstallation
 
 To reset your project and start with a fresh WordPress installation, run:
@@ -51,3 +75,4 @@ Note: You must provide the `ADMIN_PASSWORD` environment variable when running th
 
 - Not all WordPress plugins support SQLite. Some plugins use MySQL-specific syntax when creating additional tables.
 - When using automated setup, if any required environment variables are missing, the installer will prompt you to provide them before proceeding.
+- When running with Docker, any changes to environment variables require a container restart: `docker-compose restart`

--- a/README.md
+++ b/README.md
@@ -1,8 +1,8 @@
 # LitePress
 
-This is a personal project which will setup WordPress using composer and will install sqlite integration plugin automatically.
+This is a personal project that will set up WordPress using composer and will install sqlite integration plugin automatically.
 
-The `mu-plugins` folder contains some plugins I copied from a WordPress project created by **Wordpress Studio**.
+The `mu-plugins` folder contains some plugins I copied from a WordPress project created by **WordPress Studio**.
 
 ## Creating a Project
 
@@ -39,9 +39,9 @@ After installation is complete, you can login to your WordPress dashboard using 
 
 ## Running with Docker
 
-The project includes Docker support for easy development. To run the project using Docker:
+The project includes Docker support to facilitate easy development. To run the project using Docker:
 
-1. Make sure you have Docker and Docker Compose installed on your system.
+1. Make sure you have Docker and Docker Compose installed on your system and the project is installed using one of the above installation steps.
 
 2. (Optional) Configure the environment variables in `.env`:
    ```env
@@ -49,12 +49,12 @@ The project includes Docker support for easy development. To run the project usi
    REDIS_PORT=6379     # Change if port 6379 is already in use
    ```
 
-4. Start the Docker containers:
+3. Start the Docker containers:
    ```bash
    docker-compose up -d
    ```
 
-5. Your application will be available at `http://127.0.0.1` (or the port you specified in NGINX_PORT).
+4. Your application will be available at `http://127.0.0.1` (or the port you specified in NGINX_PORT).
 
 The Docker setup includes:
 - PHP-FPM with Nginx

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,0 +1,38 @@
+services:
+  wpapp:
+    build:
+      context: .
+      dockerfile: docker/Dockerfile
+    ports:
+      - "${NGINX_PORT:-80}:80"
+    volumes:
+      - .:/var/www/html
+    environment:
+      - NGINX_PORT=${NGINX_PORT:-80}
+      - APP_ENV=${APP_ENV:-local}
+      - APP_DEBUG=${APP_DEBUG:-true}
+    networks:
+      - litepress
+
+  # Add Redis for caching
+  redis:
+    image: redis:alpine
+    ports:
+      - "${REDIS_PORT:-6379}:6379"
+    networks:
+      - litepress
+    volumes:
+      - redis-data:/data
+    healthcheck:
+      test: ["CMD", "redis-cli", "ping"]
+      interval: 30s
+      timeout: 10s
+      retries: 3
+
+networks:
+  litepress:
+    driver: bridge
+
+volumes:
+  redis-data:
+    driver: local

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -2,11 +2,10 @@ services:
   wpapp:
     build:
       context: .
-      dockerfile: docker/Dockerfile
     ports:
       - "${NGINX_PORT:-80}:80"
     volumes:
-      - .:/var/www/html
+      - .:/var/www
     environment:
       - NGINX_PORT=${NGINX_PORT:-80}
       - APP_ENV=${APP_ENV:-local}

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -1,0 +1,57 @@
+# Use an official PHP-FPM base image
+FROM php:8.4-fpm
+
+# Install required packages and PHP extensions
+RUN apt-get update && apt-get install -y \
+    nginx \
+    curl \
+    zip \
+    unzip \
+    git \
+    libpng-dev \
+    libonig-dev \
+    libxml2-dev \
+    libzip-dev \
+    supervisor \
+    wget \
+    && docker-php-ext-install \
+        mbstring \
+        exif \
+        pcntl \
+        bcmath \
+        gd \
+        zip \
+        opcache \
+    && apt-get clean && rm -rf /var/lib/apt/lists/*
+
+# Install confd
+RUN wget https://github.com/kelseyhightower/confd/releases/download/v0.16.0/confd-0.16.0-linux-amd64 \
+    && mv confd-0.16.0-linux-amd64 /usr/local/bin/confd \
+    && chmod +x /usr/local/bin/confd
+
+# Set working directory
+WORKDIR /var/www/html
+
+# Create confd structure
+RUN mkdir -p /etc/confd/{conf.d,templates}
+
+# Copy confd configuration
+COPY ./docker/confd/conf.d /etc/confd/conf.d/
+COPY ./docker/confd/templates /etc/confd/templates/
+
+# Copy Supervisor configuration
+COPY ./docker/supervisord.conf /etc/supervisor/conf.d/supervisord.conf
+
+# Copy entrypoint script
+COPY ./docker/docker-entrypoint.sh /usr/local/bin/
+RUN chmod +x /usr/local/bin/docker-entrypoint.sh
+
+# Set default port
+ENV NGINX_PORT=80
+
+# Expose the port dynamically
+EXPOSE ${NGINX_PORT}
+
+# Start services
+ENTRYPOINT ["docker-entrypoint.sh"]
+CMD ["supervisord", "-c", "/etc/supervisor/conf.d/supervisord.conf"]

--- a/docker/confd/conf.d/nginx.toml
+++ b/docker/confd/conf.d/nginx.toml
@@ -1,0 +1,6 @@
+[template]
+src = "nginx.conf.tmpl"
+dest = "/etc/nginx/sites-available/default"
+keys = [
+    "NGINX_PORT"
+]

--- a/docker/confd/templates/nginx.conf.tmpl
+++ b/docker/confd/templates/nginx.conf.tmpl
@@ -1,0 +1,23 @@
+server {
+    listen {{getenv "NGINX_PORT"}};
+    server_name localhost;
+
+    root /var/www/public;
+    index index.php index.html;
+
+    location / {
+        try_files $uri $uri/ /index.php?$query_string;
+    }
+
+    location ~ \.php$ {
+        include snippets/fastcgi-php.conf;
+        fastcgi_pass 127.0.0.1:9000;
+        fastcgi_param SCRIPT_FILENAME $document_root$fastcgi_script_name;
+        fastcgi_param PATH_INFO $fastcgi_path_info;
+        fastcgi_param SERVER_PORT {{getenv "NGINX_PORT"}};
+    }
+
+    location ~ /\.ht {
+        deny all;
+    }
+}

--- a/docker/docker-entrypoint.sh
+++ b/docker/docker-entrypoint.sh
@@ -1,0 +1,8 @@
+#!/bin/sh
+set -e
+
+# Run confd
+confd -onetime -backend env
+
+# Execute CMD
+exec "$@"

--- a/docker/docker-entrypoint.sh
+++ b/docker/docker-entrypoint.sh
@@ -2,7 +2,7 @@
 set -e
 
 # Run confd
-confd -onetime -backend env
+/usr/local/bin/confd -onetime -backend env
 
 # Execute CMD
 exec "$@"

--- a/docker/php/custom.ini
+++ b/docker/php/custom.ini
@@ -1,0 +1,1 @@
+; add all the new values here

--- a/docker/supervisord.conf
+++ b/docker/supervisord.conf
@@ -3,6 +3,7 @@ nodaemon=true
 logfile=/dev/stdout
 logfile_maxbytes=0
 loglevel=info
+pidfile=/var/run/supervisord.pid
 
 [program:php-fpm]
 command=/usr/local/sbin/php-fpm --nodaemonize

--- a/docker/supervisord.conf
+++ b/docker/supervisord.conf
@@ -1,0 +1,23 @@
+[supervisord]
+nodaemon=true
+logfile=/dev/stdout
+logfile_maxbytes=0
+loglevel=info
+
+[program:php-fpm]
+command=/usr/local/sbin/php-fpm --nodaemonize
+autostart=true
+autorestart=true
+stdout_logfile=/dev/stdout
+stdout_logfile_maxbytes=0
+stderr_logfile=/dev/stderr
+stderr_logfile_maxbytes=0
+
+[program:nginx]
+command=/usr/sbin/nginx -g "daemon off;"
+autostart=true
+autorestart=true
+stdout_logfile=/dev/stdout
+stdout_logfile_maxbytes=0
+stderr_logfile=/dev/stderr
+stderr_logfile_maxbytes=0


### PR DESCRIPTION
> [!NOTE]
> Thanks to @Lewiscowles1986 for the starting code.

Add Docker Support for Local Development

This PR introduces Docker support to streamline the local development environment setup. 

The changes include:

- Add `docker-compose.yml` with:
  - PHP-FPM & Nginx service using existing Dockerfile
  - Redis service for caching
  - Network and volume configurations
  - Environment variable support for ports customization

- Update README.md with:
  - New "Running with Docker" section
  - Docker setup instructions
  - Environment configuration guide
  - Container management notes

These changes make it easier for developers to get started with the project by providing a consistent development environment across different machines.

No changes were made to the core application code - this is purely for development environment setup.